### PR TITLE
Add AST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ docs: doc/regexp/index.html
 doc/%/index.html: %.rs
 	rustdoc $<
 
-MC_FILES := src/main.rs src/lexer.rs src/parser.rs src/span.rs
+MC_FILES := src/main.rs src/lexer.rs src/parser.rs src/span.rs src/ast.rs
 
 mc: $(MC_FILES)
 	rustc $< -o $@

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,294 @@
+use lexer::{Token, SourceToken};
+use span::{Spanned};
+use std::fmt::{Formatter, Result, Show};
+
+// Spanned type decls
+macro_rules! spanned {
+    ( $( $s:ident => $n:ident ),* ) => ( $( pub type $s = Spanned<$n>; )* )
+}
+
+spanned! {
+    Type     => TypeNode,
+    BinOp    => BinOpNode,
+    UnOp     => UnOpNode,
+    Lit      => LitNode,
+    Expr     => ExprNode,
+    FuncArg  => FuncArgNode,
+    Block    => BlockNode,
+    Stmt     => StmtNode,
+    Item     => ItemNode
+}
+
+#[deriving(Eq, Clone)]
+pub struct IntKind {
+    pub signedness: Signedness,
+    pub width: Width,
+}
+
+impl Show for IntKind {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f.buf, "{}{}", self.signedness.show_char(), self.width)
+    }
+}
+
+#[deriving(Eq, Show, Clone)]
+pub enum Signedness {
+    Signed,
+    Unsigned,
+}
+
+impl Signedness {
+    fn show_char(&self) -> &'static str {
+        match *self {
+            Signed => "i",
+            Unsigned => "u"
+        }
+    }
+}
+
+#[deriving(Eq, Clone)]
+pub enum Width {
+    Width32,
+    Width16,
+    Width8
+}
+
+impl Show for Width {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f.buf, "{}", match *self {
+            Width32 => 32,
+            Width16 => 16,
+            Width8  => 8,
+        })
+    }
+}
+
+/// Types
+#[deriving(Eq)]
+pub enum TypeNode {
+    BoolType,
+    UnitType,
+    IntType(IntKind),
+    PointerTo(~Type),
+    NamedType(~str /* module path */),
+    FuncType(~Type, ~Type),
+    ArrayType(~Type, u64),
+    TupleType(Vec<Type>),
+    ParamType(~str /* ident */),
+}
+
+impl Show for TypeNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match *self {
+            BoolType                => write!(f.buf, "bool"),
+            UnitType                => write!(f.buf, "()"),
+            IntType(k)              => write!(f.buf, "{}", k),
+            PointerTo(ref t)        => write!(f.buf, "*{}", t),
+            NamedType(ref n)        => write!(f.buf, "{}", n),
+            FuncType(ref d, ref r)  => write!(f.buf, "{} -> {}", d, r),
+            ArrayType(ref t, d)     => write!(f.buf, "{}[{}]", t, d),
+            TupleType(ref ts)       => write!(f.buf, "({})", ts),
+            ParamType(ref n)        => write!(f.buf, "{}", n),
+        }
+    }
+}
+
+#[deriving(Eq)]
+pub enum BinOpNode {
+    Plus,
+    Minus,
+    Times,
+    Divide,
+    Mod,
+    Equals,
+    Less,
+    LessEq,
+    Greater,
+    GreaterEq,
+    AndAlso,
+    OrElse,
+    BitAnd,
+    BitOr,
+    BitXor,
+}
+
+impl Show for BinOpNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f.buf, "{}", match *self {
+            Plus      => "+",
+            Minus     => "-",
+            Times     => "*",
+            Divide    => "/",
+            Mod       => "%",
+            Equals    => "==",
+            Less      => "<",
+            LessEq    => "<=",
+            Greater   => ">",
+            GreaterEq => ">=",
+            AndAlso   => "&&",
+            OrElse    => "||",
+            BitAnd    => "&",
+            BitOr     => "|",
+            BitXor    => "^",
+        })
+    }
+}
+
+#[deriving(Eq)]
+pub enum UnOpNode {
+    Deref,
+    AddrOf,
+}
+
+impl Show for UnOpNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f.buf, "{}", match *self {
+            Deref  => "*",
+            AddrOf => "&"
+        })
+    }
+}
+
+#[deriving(Eq)]
+pub enum LitNode {
+    NumLit(u64, IntKind),
+    StringLit(~str),
+    BoolLit(bool),
+    UnitLit,
+    TupleLit(Vec<Lit>)
+}
+
+impl Show for LitNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match *self {
+            NumLit(i, nt)     => write!(f.buf, "{}{}", i, nt),
+            StringLit(ref s)  => write!(f.buf, "\"{}\"", s),
+            BoolLit(b)        => write!(f.buf, "{}", b),
+            UnitLit           => write!(f.buf, "()"),
+            TupleLit(ref vs)  => write!(f.buf, "({})", vs),
+        }
+    }
+}
+
+pub enum ExprNode {
+    LitExpr(Lit),
+    IdentExpr(~str /* ident */),
+    BinOpExpr(BinOp, ~Expr, ~Expr),
+    UnOpExpr(UnOp, ~Expr),
+    IndexExpr(~Expr, ~Expr),
+    FieldExpr(~Expr, ~str /* ident */),
+    AssignExpr(~Expr, ~Expr),
+    CallExpr(~Expr, Vec<Expr>),
+    CastExpr(~Expr, Type),
+    IfExpr(~Expr, ~Block, ~Block),
+    BlockExpr(~Block),
+    ReturnExpr(~Expr),
+}
+
+impl Show for ExprNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match *self {
+            LitExpr(ref l)                  => write!(f.buf, "{}", l),
+            IdentExpr(ref id)               => write!(f.buf, "{}", id),
+            BinOpExpr(op, ref l, ref r)     => write!(f.buf, "({}{}{})", l, op, r),
+            UnOpExpr(op, ref e)             => write!(f.buf, "({}{})", op, e),
+            IndexExpr(ref e, ref i)         => write!(f.buf, "{}[{}]", e, i),
+            FieldExpr(ref e, ref fld)       => write!(f.buf, "{}.{}", e, fld),
+            AssignExpr(ref lv, ref rv)      => write!(f.buf, "({}={})", lv, rv),
+            CallExpr(ref id, ref args)      => write!(f.buf, "{}({})", id, args),
+            CastExpr(ref e, ref t)          => write!(f.buf, "({} as {})", e, t),
+            IfExpr(ref c, ref bt, ref bf)   => write!(f.buf, "if {} \\{\n{}\\} else \\{\n{}\\}", c, bt, bf),
+            BlockExpr(ref b)                => write!(f.buf, "{}", b),
+            ReturnExpr(ref e)               => write!(f.buf, "return {}", e),
+        }
+    }
+}
+
+pub enum StmtNode {
+    LetStmt(~str /* ident now, pattern eventually */, Type, Option<Expr>),
+    ExprStmt(Expr), // no trailing semicolon, must have unit type
+    SemiStmt(Expr), // trailing semicolon, any type OK
+}
+
+impl Show for StmtNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match *self {
+            LetStmt(ref id, ref t, ref expr) => {
+                try!(write!(f.buf, "let {}: {}", id, t));
+                match *expr {
+                    Some(ref e) => { try!(write!(f.buf, " = {}", e)); },
+                    None => {}
+                }
+                try!(write!(f.buf, ";"));
+            },
+            ExprStmt(ref e) => {
+                try!(write!(f.buf, "{}", e));
+            },
+            SemiStmt(ref e) => {
+                try!(write!(f.buf, "{};", e));
+            },
+        }
+        Ok(())
+    }
+}
+
+pub struct BlockNode {
+    items: Vec<Item>,
+    stmts: Vec<Stmt>,
+    expr:  Option<Expr>,
+}
+
+impl Show for BlockNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        try!(write!(f.buf, "{}\n", "{"));
+        for item in self.items.iter() {
+            for line in format!("{}", item).lines() {
+                try!(write!(f.buf, "    {}\n", line));
+            }
+        }
+        for stmt in self.stmts.iter() {
+            for line in format!("{}", stmt).lines() {
+                try!(write!(f.buf, "    {}\n", line));
+            }
+        }
+        match self.expr {
+            Some(ref e) => {
+                for line in format!("{}", e).lines() {
+                    try!(write!(f.buf, "    {}\n", line));
+                }
+            },
+            None => {}
+        }
+        write!(f.buf, "{}", "}")
+    }
+}
+
+pub struct FuncArgNode {
+    name: ~str /* ident */,
+    argtype: Type
+}
+
+impl Show for FuncArgNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f.buf, "{}: {}", self.name, self.argtype)
+    }
+}
+
+pub enum ItemNode {
+    FuncItem(~str /* ident */, Vec<FuncArg>, Type, Block, Vec<~str>),
+}
+
+impl Show for ItemNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match *self {
+            FuncItem(ref id, ref args, ref t, ref def, ref tps) => {
+                try!(write!(f.buf, "fn {}", id));
+                if tps.len() > 0 {
+                    try!(write!(f.buf, "<{}>", tps));
+                }
+                try!(write!(f.buf, "({}) -> {} {}", args, t, def))
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use parser::Parser;
 mod lexer;
 mod parser;
 mod span;
+mod ast;
 
 fn main() {
     println!("moroso compiler");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+use ast::IntKind;
 use lexer::*;
 use lexer::SourceToken;
 use std::fmt::{Formatter, Result, Show};
@@ -5,33 +6,10 @@ use std::iter::Peekable;
 use std::num;
 use std::vec;
 
-#[deriving(Eq, Clone)]
-pub struct NumberType {
-    pub signedness: Signedness,
-    pub width: u8,
-}
-
-#[deriving(Eq, Clone, Show)]
-pub enum Signedness {
-    Signed,
-    Unsigned,
-}
-
-impl Show for NumberType {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f.buf, "{}{}",
-               match self.signedness {
-                   Signed => 'i',
-                   Unsigned => 'u',
-               },
-               self.width)
-    }
-}
-
 // Numbers by default are 32-bit, signed.
 mod defaults {
-    use super::{NumberType, Signed};
-    pub static DEFAULT_NUM_TYPE: NumberType = NumberType { signedness: Signed, width: 32 };
+    use ast::{IntKind, Signed, Width32};
+    pub static DEFAULT_INT_KIND: IntKind = IntKind { signedness: Signed, width: Width32 };
 }
 
 #[deriving(Eq, Show)]
@@ -43,7 +21,7 @@ pub enum CompoundExpressionComponent {
 
 #[deriving(Eq)]
 pub enum ExpressionComponent {
-    Num(u64, NumberType),
+    Num(u64, IntKind),
     StringConstant(~str),
     TrueConstant,
     FalseConstant,
@@ -308,7 +286,7 @@ impl<T: Iterator<SourceToken>> Parser<SourceToken, T> {
             True              => TrueConstant,
             False             => FalseConstant,
             String(s)         => StringConstant(s),
-            Number(num, kind) => Num(num, kind.unwrap_or(defaults::DEFAULT_NUM_TYPE)),
+            Number(num, kind) => Num(num, kind.unwrap_or(defaults::DEFAULT_INT_KIND)),
             tok               => self.error(format!("Unexpected {} where literal expected", tok))
         }
     }
@@ -780,7 +758,7 @@ mod tests {
     use super::ExpressionComponent;
 
     fn mknum(n: u64) -> ExpressionComponent {
-        Num(n, defaults::DEFAULT_NUM_TYPE)
+        Num(n, defaults::DEFAULT_INT_KIND)
     }
 
     #[test]


### PR DESCRIPTION
This is a refactor of the AST that currently exists in Parser that has slightly shorter names, may be a little friendlier to traverse, and works well with spans.  Refactoring the parser to use this AST will take a fair chunk of time, but the conversion should be pretty easy at least.  Some useful notes:
- The Show impl for Block will (read: should) autoindent and does not leave a trailing newline after the closing brace.
- FuncDecls take a Block as their body definition.
- IfExprs take an Expr and two Blocks.
- ParamType has an ident -- the intention is these are created when an ident in a type position matches any element of a FuncDecl's type parameter vector.  As a sanity check, when they are later used, the user should verify that the ident exists in the FuncDecl's vector.
